### PR TITLE
Corrected formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 ## Usage:
 
 ```yaml
-uses: apple-actions/upload-testflight-build@v1
-with: 
-  app-path: 'path/to/application.ipa`  
-  issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
-  api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
-  api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+- name: 'Upload app to TestFlight'
+  uses: apple-actions/upload-testflight-build@v1
+  with: 
+    app-path: 'path/to/application.ipa' 
+    issuer-id: ${{ secrets.APPSTORE_ISSUER_ID }}
+    api-key-id: ${{ secrets.APPSTORE_API_KEY_ID }}
+    api-private-key: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
 ```
 
 ## Additional Arguments


### PR DESCRIPTION
## Summary
Previously the example snippet had a backtick instead of a single quote. I reformatted to include the `- name:` style you used in https://github.com/Apple-Actions/download-provisioning-profiles