### PR TITLE
update node version from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ outputs:
   altool-response:
     description: 'XML output from altool'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'arrow-up-circle'


### PR DESCRIPTION
fixes #37 

getting warning on Github Actions.

I know it doesn't break anything but would be good to have warning free workflow.

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: apple-actions/upload-testflight-build@v