### PR TITLE
Replace appType osx to macos

### DIFF
--- a/src/altool.ts
+++ b/src/altool.ts
@@ -2,12 +2,12 @@ import * as path from 'path'
 import * as io from '@actions/io'
 import * as fs from 'fs'
 import * as exec from '@actions/exec'
-import {ExecOptions} from '@actions/exec/lib/interfaces'
+import { ExecOptions } from '@actions/exec/lib/interfaces'
 
 /**
  Upload the specified application.
  @param appPath The path to the app to upload.
- @param appType The type of app to upload (osx | ios | appletvos)
+ @param appType The type of app to upload (macos | ios | appletvos)
  @param apiKeyId The id of the API key to use (private key must already be installed)
  @param issuerId The issuer identifier of the API key.
  @param options (Optional) Command execution options.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import * as os from 'os'
 import * as altool from './altool'
 
-import {ExecOptions} from '@actions/exec/lib/interfaces'
+import { ExecOptions } from '@actions/exec/lib/interfaces'
 
 async function run(): Promise<void> {
   try {


### PR DESCRIPTION
Replace `osx` to `macos` according to values listed when running `xcrun altool --help` for `--type` param