### PR TITLE
Fixed set-output to new GitHub Environment Variables

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15084,7 +15084,7 @@ exports.getInput = getInput;
  * @param     value    value to store
  */
 function setOutput(name, value) {
-    command_1.issueCommand('set-output', { name }, value);
+    process.stdout.write(`"{${name}}={${value}}" >> $GITHUB_OUTPUT` + os.EOL);
 }
 exports.setOutput = setOutput;
 //-----------------------------------------------------------------------


### PR DESCRIPTION
Resolves #40 

This is a temporary work around to get builds working.

I think the real fix will involve merging with the template repo