### PR TITLE
Add optional apple-id parameter for Xcode 26+ compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   api-private-key:
     description: 'The PKCS8 format Private Key for AppStore Connect API'
     required: true
+  apple-id:
+    description: 'The Apple ID of the app to upload (required for Xcode 26+)'
+    required: false
 outputs:
   altool-response:
     description: 'XML output from altool'

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,9 +20,10 @@ const exec_1 = __nccwpck_require__(5236);
  @param appType The type of app to upload (macos | ios | appletvos | visionos)
  @param apiKeyId The id of the API key to use (private key must already be installed)
  @param issuerId The issuer identifier of the API key.
+ @param appleId (Optional) The Apple ID of the app to upload (required for Xcode 26+).
  @param options (Optional) Command execution options.
  */
-async function uploadApp(appPath, appType, apiKeyId, issuerId, options) {
+async function uploadApp(appPath, appType, apiKeyId, issuerId, appleId, options) {
     const args = [
         'altool',
         '--output-format',
@@ -37,6 +38,9 @@ async function uploadApp(appPath, appType, apiKeyId, issuerId, options) {
         '--apiIssuer',
         issuerId
     ];
+    if (appleId) {
+        args.push('--apple-id', appleId);
+    }
     await (0, exec_1.exec)('xcrun', args, options);
 }
 function privateKeysPath() {
@@ -27630,6 +27634,7 @@ async function run() {
         const apiPrivateKey = (0, core_1.getInput)('api-private-key');
         const appPath = (0, core_1.getInput)('app-path');
         const appType = (0, core_1.getInput)('app-type');
+        const appleId = (0, core_1.getInput)('apple-id');
         let output = '';
         const options = {};
         options.listeners = {
@@ -27638,7 +27643,7 @@ async function run() {
             }
         };
         await (0, altool_1.installPrivateKey)(apiKeyId, apiPrivateKey);
-        await (0, altool_1.uploadApp)(appPath, appType, apiKeyId, issuerId, options);
+        await (0, altool_1.uploadApp)(appPath, appType, apiKeyId, issuerId, appleId, options);
         await (0, altool_1.deleteAllPrivateKeys)();
         (0, core_1.setOutput)('altool-response', output);
     }

--- a/src/altool.ts
+++ b/src/altool.ts
@@ -10,6 +10,7 @@ import {ExecOptions} from '@actions/exec/lib/interfaces'
  @param appType The type of app to upload (macos | ios | appletvos | visionos)
  @param apiKeyId The id of the API key to use (private key must already be installed)
  @param issuerId The issuer identifier of the API key.
+ @param appleId (Optional) The Apple ID of the app to upload (required for Xcode 26+).
  @param options (Optional) Command execution options.
  */
 export async function uploadApp(
@@ -17,6 +18,7 @@ export async function uploadApp(
   appType: string,
   apiKeyId: string,
   issuerId: string,
+  appleId?: string,
   options?: ExecOptions
 ): Promise<void> {
   const args: string[] = [
@@ -33,6 +35,10 @@ export async function uploadApp(
     '--apiIssuer',
     issuerId
   ]
+
+  if (appleId) {
+    args.push('--apple-id', appleId)
+  }
 
   await exec('xcrun', args, options)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ async function run(): Promise<void> {
     const apiPrivateKey: string = getInput('api-private-key')
     const appPath: string = getInput('app-path')
     const appType: string = getInput('app-type')
+    const appleId: string = getInput('apple-id')
 
     let output = ''
     const options: ExecOptions = {}
@@ -25,7 +26,7 @@ async function run(): Promise<void> {
     }
 
     await installPrivateKey(apiKeyId, apiPrivateKey)
-    await uploadApp(appPath, appType, apiKeyId, issuerId, options)
+    await uploadApp(appPath, appType, apiKeyId, issuerId, appleId, options)
     await deleteAllPrivateKeys()
 
     setOutput('altool-response', output)


### PR DESCRIPTION
Adds --apple-id flag support to altool command to fix bundle identifier errors when uploading with Xcode 26. The parameter is optional to maintain backward compatibility.

Fixes: https://developer.apple.com/forums/thread/803105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Edit: Relevant for #123 