### PR TITLE
Fix expired credentials after the 5th processing wait attempt

### DIFF
--- a/src/backends/appstore-api.ts
+++ b/src/backends/appstore-api.ts
@@ -62,7 +62,9 @@ export const appstoreApi: Uploader = {
         appId,
         buildNumber: metadata.buildNumber,
         platform,
-        token
+        issuerId: params.issuerId,
+        apiKeyId: params.apiKeyId,
+        apiPrivateKey: params.apiPrivateKey
       })
     } else {
       info('Skipping wait for App Store processing per configuration.')
@@ -284,16 +286,28 @@ async function pollBuildProcessing(params: {
   appId: string
   buildNumber: string
   platform: string
-  token: string
+  issuerId: string
+  apiKeyId: string
+  apiPrivateKey: string
 }): Promise<void> {
-  await waitForBuildProcessing(params, {
-    visibilityAttempts: VISIBILITY_ATTEMPTS,
-    visibilityDelayMs: VISIBILITY_DELAY_MS,
-    processingAttempts: MAX_PROCESSING_ATTEMPTS,
-    processingDelayMs: PROCESSING_DELAY_MS,
-    onRetry: message =>
-      warning(`Waiting for build ${params.buildNumber}: ${message}`)
-  })
+  const tokenFactory = () =>
+    generateJwt(params.issuerId, params.apiKeyId, params.apiPrivateKey)
+  await waitForBuildProcessing(
+    {
+      appId: params.appId,
+      buildNumber: params.buildNumber,
+      platform: params.platform,
+      token: tokenFactory
+    },
+    {
+      visibilityAttempts: VISIBILITY_ATTEMPTS,
+      visibilityDelayMs: VISIBILITY_DELAY_MS,
+      processingAttempts: MAX_PROCESSING_ATTEMPTS,
+      processingDelayMs: PROCESSING_DELAY_MS,
+      onRetry: message =>
+        warning(`Waiting for build ${params.buildNumber}: ${message}`)
+    }
+  )
 
   info('Build upload completed and processing is VALID.')
 }

--- a/src/backends/appstore-api.ts
+++ b/src/backends/appstore-api.ts
@@ -16,11 +16,8 @@ const VISIBILITY_DELAY_MS = 60000 // 1 minute initial wait before polling visibi
 export const appstoreApi: Uploader = {
   async upload(params: UploadParams): Promise<UploadResult> {
     info('Starting App Store API upload backend.')
-    const token = generateJwt(
-      params.issuerId,
-      params.apiKeyId,
-      params.apiPrivateKey
-    )
+    const makeToken = () =>
+      generateJwt(params.issuerId, params.apiKeyId, params.apiPrivateKey)
     const metadata = await extractAppMetadata(params.appPath)
     debug(
       `Extracted metadata: bundleId=${metadata.bundleId}, buildNumber=${metadata.buildNumber}, shortVersion=${metadata.shortVersion}`
@@ -34,7 +31,7 @@ export const appstoreApi: Uploader = {
       `Preparing build upload for platform=${platform}, file=${fileName}, size=${fileSize} bytes`
     )
 
-    const appId = await lookupAppId(metadata.bundleId, token)
+    const appId = await lookupAppId(metadata.bundleId, makeToken())
     debug(`Resolved appId=${appId} for bundleId=${metadata.bundleId}`)
 
     const buildUpload = await createBuildUpload(
@@ -46,7 +43,7 @@ export const appstoreApi: Uploader = {
         fileName,
         fileSize
       },
-      token
+      makeToken()
     )
     debug(
       `Created build upload id=${buildUpload.id}, operations=${buildUpload.uploadOperations.length}`
@@ -54,7 +51,7 @@ export const appstoreApi: Uploader = {
 
     await performUpload(buildUpload, params.appPath)
     info('Finished uploading build chunks.')
-    await completeBuildUpload(buildUpload.fileId, token)
+    await completeBuildUpload(buildUpload.fileId, makeToken())
     info('Marked build upload as complete; waiting for processing.')
 
     if (params.waitForProcessing !== false) {
@@ -62,9 +59,7 @@ export const appstoreApi: Uploader = {
         appId,
         buildNumber: metadata.buildNumber,
         platform,
-        issuerId: params.issuerId,
-        apiKeyId: params.apiKeyId,
-        apiPrivateKey: params.apiPrivateKey
+        getToken: makeToken
       })
     } else {
       info('Skipping wait for App Store processing per configuration.')
@@ -286,28 +281,16 @@ async function pollBuildProcessing(params: {
   appId: string
   buildNumber: string
   platform: string
-  issuerId: string
-  apiKeyId: string
-  apiPrivateKey: string
+  getToken: () => string
 }): Promise<void> {
-  const tokenFactory = () =>
-    generateJwt(params.issuerId, params.apiKeyId, params.apiPrivateKey)
-  await waitForBuildProcessing(
-    {
-      appId: params.appId,
-      buildNumber: params.buildNumber,
-      platform: params.platform,
-      token: tokenFactory
-    },
-    {
-      visibilityAttempts: VISIBILITY_ATTEMPTS,
-      visibilityDelayMs: VISIBILITY_DELAY_MS,
-      processingAttempts: MAX_PROCESSING_ATTEMPTS,
-      processingDelayMs: PROCESSING_DELAY_MS,
-      onRetry: message =>
-        warning(`Waiting for build ${params.buildNumber}: ${message}`)
-    }
-  )
+  await waitForBuildProcessing(params, {
+    visibilityAttempts: VISIBILITY_ATTEMPTS,
+    visibilityDelayMs: VISIBILITY_DELAY_MS,
+    processingAttempts: MAX_PROCESSING_ATTEMPTS,
+    processingDelayMs: PROCESSING_DELAY_MS,
+    onRetry: message =>
+      warning(`Waiting for build ${params.buildNumber}: ${message}`)
+  })
 
   info('Build upload completed and processing is VALID.')
 }

--- a/src/buildMetadata.ts
+++ b/src/buildMetadata.ts
@@ -38,20 +38,17 @@ export async function submitBuildMetadataUpdates(params: {
   }
 
   const metadata = await extractAppMetadata(params.appPath)
-  const token = generateJwt(
-    params.issuerId,
-    params.apiKeyId,
-    params.apiPrivateKey
-  )
+  const makeToken = () =>
+    generateJwt(params.issuerId, params.apiKeyId, params.apiPrivateKey)
   const platform = buildPlatform(params.appType)
 
-  const appId = await lookupAppId(metadata.bundleId, token)
+  const appId = await lookupAppId(metadata.bundleId, makeToken())
   const buildId = await lookupBuildIdWithRetry(
     {
       appId,
       buildNumber: metadata.buildNumber,
       platform,
-      token
+      token: makeToken
     },
     20,
     30000,
@@ -64,33 +61,35 @@ export async function submitBuildMetadataUpdates(params: {
     }
   )
   if (wantsReleaseNotes) {
-    const localizationId = await lookupLocalizationId(buildId, token)
-    await updateReleaseNotes(localizationId, trimmed, token)
+    const localizationId = await lookupLocalizationId(buildId, makeToken)
+    await updateReleaseNotes(localizationId, trimmed, makeToken())
   }
   if (wantsEncryptionUpdate) {
     await updateEncryptionCompliance(
       buildId,
       parsedEncryption as boolean,
-      token
+      makeToken()
     )
   }
 }
 
 async function lookupLocalizationId(
   buildId: string,
-  token: string
+  token: string | (() => string)
 ): Promise<string> {
   const MAX_ATTEMPTS = 20
   const RETRY_DELAY_MS = 30000
 
   const result = await pollUntil(
     async () => {
+      const resolvedToken =
+        typeof token === 'function' ? token() : token
       const response = await fetchJson<{
         data?: Array<{id?: string}>
       }>(
         // Docs: https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizations
         `/builds/${buildId}/betaBuildLocalizations`,
-        token,
+        resolvedToken,
         'Failed to query beta build localizations.'
       )
 

--- a/src/buildMetadata.ts
+++ b/src/buildMetadata.ts
@@ -48,7 +48,7 @@ export async function submitBuildMetadataUpdates(params: {
       appId,
       buildNumber: metadata.buildNumber,
       platform,
-      token: makeToken
+      getToken: makeToken
     },
     20,
     30000,
@@ -75,21 +75,19 @@ export async function submitBuildMetadataUpdates(params: {
 
 async function lookupLocalizationId(
   buildId: string,
-  token: string | (() => string)
+  getToken: () => string
 ): Promise<string> {
   const MAX_ATTEMPTS = 20
   const RETRY_DELAY_MS = 30000
 
   const result = await pollUntil(
     async () => {
-      const resolvedToken =
-        typeof token === 'function' ? token() : token
       const response = await fetchJson<{
         data?: Array<{id?: string}>
       }>(
         // Docs: https://developer.apple.com/documentation/appstoreconnectapi/betabuildlocalizations
         `/builds/${buildId}/betaBuildLocalizations`,
-        resolvedToken,
+        getToken(),
         'Failed to query beta build localizations.'
       )
 

--- a/src/utils/buildLookup.ts
+++ b/src/utils/buildLookup.ts
@@ -5,11 +5,7 @@ type BuildLookupParams = {
   appId: string
   buildNumber: string
   platform: string
-  token: string | (() => string)
-}
-
-function resolveToken(token: string | (() => string)): string {
-  return typeof token === 'function' ? token() : token
+  getToken: () => string
 }
 
 const DEFAULT_ATTEMPTS = 20
@@ -30,7 +26,7 @@ export async function lookupBuildIdWithRetry(
       }>(
         // Docs: https://developer.apple.com/documentation/appstoreconnectapi/builds
         `/builds?${query}`,
-        resolveToken(params.token),
+        params.getToken(),
         'Failed to query builds.'
       )
       return response.data?.[0]?.id
@@ -52,7 +48,7 @@ export async function lookupBuildState(
   }>(
     // Docs: https://developer.apple.com/documentation/appstoreconnectapi/builds
     `/builds?${query}`,
-    resolveToken(params.token),
+    params.getToken(),
     'Failed to query builds for processing state.'
   )
 

--- a/src/utils/buildLookup.ts
+++ b/src/utils/buildLookup.ts
@@ -5,7 +5,11 @@ type BuildLookupParams = {
   appId: string
   buildNumber: string
   platform: string
-  token: string
+  token: string | (() => string)
+}
+
+function resolveToken(token: string | (() => string)): string {
+  return typeof token === 'function' ? token() : token
 }
 
 const DEFAULT_ATTEMPTS = 20
@@ -26,7 +30,7 @@ export async function lookupBuildIdWithRetry(
       }>(
         // Docs: https://developer.apple.com/documentation/appstoreconnectapi/builds
         `/builds?${query}`,
-        params.token,
+        resolveToken(params.token),
         'Failed to query builds.'
       )
       return response.data?.[0]?.id
@@ -48,7 +52,7 @@ export async function lookupBuildState(
   }>(
     // Docs: https://developer.apple.com/documentation/appstoreconnectapi/builds
     `/builds?${query}`,
-    params.token,
+    resolveToken(params.token),
     'Failed to query builds for processing state.'
   )
 

--- a/tests/appstore-api-poll.test.ts
+++ b/tests/appstore-api-poll.test.ts
@@ -18,7 +18,7 @@ describe('lookupBuildState', () => {
       appId: '123',
       buildNumber: '1',
       platform: 'IOS',
-      token: 'token'
+      getToken: () => 'token'
     })
 
     expect(state).toBe('PROCESSING')
@@ -32,7 +32,7 @@ describe('lookupBuildState', () => {
       appId: '123',
       buildNumber: '1',
       platform: 'IOS',
-      token: 'token'
+      getToken: () => 'token'
     })
 
     expect(state).toBeUndefined()


### PR DESCRIPTION
Fix the error `Error: Failed to create App Store build upload. (401)` on the 5th attempt while using `AppStoreAPI` and waiting for processing:

```json
"errors": [{
  "status": "401",
  "code": "NOT_AUTHORIZED",
  "title": "Authentication credentials are missing or invalid.",
  "detail": "Provide a properly configured and signed bearer token, and make sure that it has not expired. Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens"
}]
```